### PR TITLE
Update gardener.json

### DIFF
--- a/data/lae/advancements/bible/gardener.json
+++ b/data/lae/advancements/bible/gardener.json
@@ -279,20 +279,10 @@
 			"trigger": "minecraft:placed_block",
 			"conditions": {"block": "minecraft:grass"}
 		}
-		,"tall_grass":
-		{
-			"trigger": "minecraft:placed_block",
-			"conditions": {"block": "minecraft:tall_grass"}
-		}
 		,"fern":
 		{
 			"trigger": "minecraft:placed_block",
 			"conditions": {"block": "minecraft:fern"}
-		}
-		,"large_fern":
-		{
-			"trigger": "minecraft:placed_block",
-			"conditions": {"block": "minecraft:large_fern"}
 		}
 		,"vine":
 		{


### PR DESCRIPTION
tall_grass an large_fern cannot be obtained in survival, so have been removed from this list to make the advancement actually obtainable